### PR TITLE
polished mobile-size media queries

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -133,6 +133,18 @@ li:hover {
     }
 }
 
+@media screen and (max-width:800px) {
+    .content-container {
+        width: 95%;
+    }
+}
+
+@media screen and (max-width:768px) {
+    .occupation {
+        width: 80%;
+    }
+}
+
 @media screen and (max-width:640px) {
     .content-container {
         margin-top: 30px;
@@ -154,13 +166,14 @@ li:hover {
     .h-country-info {
         height: auto;
     }
+
+    .figures {
+        display: block;
+        margin-bottom: 10px;
+    }
 }
 
 @media screen and (max-width:535px) {
-    .content-container {
-        width: 95%;
-    }
-
     .flag-btn {
         margin: 0;
     }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -149,8 +149,8 @@ function renderCountryInfo(countryInfo) {
     occupationNameEl.textContent = countryInfo.occupationValue;
     flagImgEl.setAttribute("src", countryInfo.flagUrl);
     flagImgEl.setAttribute("alt", `${countryInfo.countryName} flag`)
-    medianSalaryEl.innerHTML = `Median Annual Salary: ${countryInfo.convertedSalary} <span id="currency-code" class="text-color-gunmetal">${countryInfo.currencyCode}</span>`;
-    medianHouseholdIncomeEl.textContent = `Median Household Income: ${countryInfo.convertedMedianHouseholdIncome} ${countryInfo.currencyCode}`;
+    medianSalaryEl.innerHTML = `Median Annual Salary: <span class="figures text-color-gunmetal">${countryInfo.convertedSalary} <span id="currency-code" class="text-color-gunmetal">${countryInfo.currencyCode}</span></span>`;
+    medianHouseholdIncomeEl.innerHTML = `Median Household Income: <span class="figures text-color-gunmetal">${countryInfo.convertedMedianHouseholdIncome} ${countryInfo.currencyCode}</span>`;
     if (countryInfo.salaryAnalysis > 100) {
         salaryAnalysisEl.innerHTML = `Pays about <span class="text-green-600">${countryInfo.salaryAnalysis - 100}% above</span> median income`;
     } else if (countryInfo.salaryAnalysis < 100) {

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
                     <h2 id="country-name" class="inline text-4xl mr-3 text-color-gunmetal"></h2>
                     <img id="flag-img" class="text-center inline" />
                 </div>
-                <h3 id="occupation-name" class="text-3xl mt-4 mb-2 pt-6 text-color-gunmetal inline-block w-1/2 border-t-4 border-color-terracotta"></h3>
+                <h3 id="occupation-name" class="occupation text-3xl mt-4 mb-2 pt-6 text-color-gunmetal inline-block w-1/2 border-t-4 border-color-terracotta"></h3>
                 <div id="country-financials" class="text-color-gunmetal">
                     <p id="median-salary" class="font-medium mb-1 text-color-gunmetal"></p>
                     <p id="median-household-income" class="font-medium mb-1 text-color-gunmetal"></p>
@@ -136,7 +136,7 @@
                         <span class="tooltip">Convert to CAD</span>
                     </button>
                 </div>
-            </main>
+            </div>
         </main>
     </div>
 


### PR DESCRIPTION
* Figure title and figure in #country-financials now have a line break at small screen sizes
* Fixed bug where #occupation-name top border could look wacky at small dimensions
* adjusted container margins at smaller dimension sizes for better readability